### PR TITLE
Comments and updates on man pages

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -25,7 +25,7 @@ This interface makes
 .B io_uring
 different from other UNIX I/O APIs,
 wherein,
-rather than just communicate between kernel and user space with system calls, 
+rather than just communicate between kernel and user space with system calls,
 ring buffers are used as the main mode of communication.
 This arrangement has various performance benefits which are discussed in a
 separate section below.
@@ -40,12 +40,12 @@ Set up shared buffers with
 .BR io_uring_setup (2)
 and
 .BR mmap (2),
-mapping into user space shared buffers for the submission queue (SQ) and the 
+mapping into user space shared buffers for the submission queue (SQ) and the
 completion queue (CQ).
 You place I/O requests you want to make on the SQ,
 while the kernel places the results of those operations on the CQ.
 .IP \(bu
-For every I/O request you need to make (like to read a file, write a file, 
+For every I/O request you need to make (like to read a file, write a file,
 accept a socket connection, etc), you create a submission queue entry,
 or SQE,
 describe the I/O operation you need to get done and add it to the tail of
@@ -77,15 +77,15 @@ you might be interested in checking the
 field of the CQE structure,
 which corresponds to the return value of the system
 call's equivalent,
-had you used it directly without using 
+had you used it directly without using
 .BR io_uring .
 For instance,
-a read operation under 
+a read operation under
 .BR io_uring ,
 started with the
 .BR IORING_OP_READ
 operation, issues the equivalent of the
-.BR read (2) 
+.BR read (2)
 system call. In practice, it mixes the semantics of
 .BR pread (2)
 and
@@ -114,7 +114,7 @@ If the normal system call would have returned a read size of 1024, then
 .I res
 would contain 1024.
 .IP \(bu
-Optionally, 
+Optionally,
 .BR io_uring_enter (2)
 can also wait for a specified number of requests to be processed by the kernel
 before it returns.
@@ -147,7 +147,7 @@ The kernel reads SQEs off the head of the queue.
 The kernel adds CQEs to the tail of the CQ.
 You read CQEs off the head of the queue.
 .SS Submission queue polling
-One of the goals of 
+One of the goals of
 .B io_uring
 is to provide a means for efficient I/O.
 To this end,
@@ -160,7 +160,7 @@ With SQ Polling,
 starts a kernel thread that polls the submission queue for any I/O
 requests you submit by adding SQEs.
 With SQ Polling enabled,
-there is no need for you to call 
+there is no need for you to call
 .BR io_uring_enter (2),
 letting you avoid the overhead of system calls.
 A designated kernel thread dequeues SQEs off the SQ as you add them and
@@ -172,33 +172,33 @@ The main steps in setting up
 consist of mapping in the shared buffers with
 .BR mmap (2)
 calls.
-In the example program included in this man page, 
+In the example program included in this man page,
 the function
 .BR app_setup_uring ()
-sets up 
+sets up
 .B io_uring
 with a QUEUE_DEPTH deep submission queue.
-Pay attention to the 2 
+Pay attention to the 2
 .BR mmap (2)
 calls that set up the shared submission and completion queues.
 If your kernel is older than version 5.4,
-three 
-.BR mmap(2) 
+three
+.BR mmap(2)
 calls are required.
 .PP
 .SS Submitting I/O requests
 The process of submitting a request consists of describing the I/O
-operation you need to get done using an 
+operation you need to get done using an
 .B io_uring_sqe
 structure instance.
 These details describe the equivalent system call and its parameters.
 Because the range of I/O operations Linux supports are very varied and the
 .B io_uring_sqe
-structure needs to be able to describe them, 
+structure needs to be able to describe them,
 it has several fields,
 some packed into unions for space efficiency.
-Here is a simplified version of struct 
-.B io_uring_sqe 
+Here is a simplified version of struct
+.B io_uring_sqe
 with some of the most often used fields:
 .PP
 .in +4n
@@ -216,7 +216,7 @@ struct io_uring_sqe {
 .EE
 .in
 
-Here is struct 
+Here is struct
 .B io_uring_sqe
 in full:
 
@@ -271,13 +271,14 @@ struct io_uring_sqe {
 .EE
 .in
 .PP
-To submit an I/O request to 
+To submit an I/O request to
 .BR io_uring ,
 you need to acquire a submission queue entry (SQE) from the submission
 queue (SQ),
-fill it up with details of the operation you want to submit and call 
-.BR io_uring_enter (2). 
-If you want to avoid calling 
+fill it up with details of the operation you want to submit and call
+.BR io_uring_enter (2).
+There are helper functions of the form io_uring_prep_X to enable proper
+setup of the SQE. If you want to avoid calling
 .BR io_uring_enter (2),
 you have the option of setting up Submission Queue Polling.
 .PP
@@ -332,11 +333,11 @@ sqe->off = offset;
 sqe->flags = 0;
 .EE
 .in
-.TP 
+.TP
 .B Memory ordering
-Modern compilers and CPUs freely reorder reads and writes without 
-affecting the program's outcome to optimize performance. 
-Some aspects of this need to be kept in mind on SMP systems since 
+Modern compilers and CPUs freely reorder reads and writes without
+affecting the program's outcome to optimize performance.
+Some aspects of this need to be kept in mind on SMP systems since
 .B io_uring
 involves buffers shared between kernel and user space.
 These buffers are both visible and modifiable from kernel and user space.
@@ -353,7 +354,7 @@ memory barriers are out of scope for further discussion on this man page.
 Once you place one or more SQEs on to the SQ,
 you need to let the kernel know that you've done so.
 You can do this by calling the
-.BR io_uring_enter (2) 
+.BR io_uring_enter (2)
 system call.
 This system call is also capable of waiting for a specified count of
 events to complete.
@@ -378,7 +379,7 @@ on the other hand is simpler since we're looking only for a return value
 back from the kernel.
 This is easily understood by looking at the completion queue event
 structure,
-struct 
+struct
 .BR io_uring_cqe :
 .PP
 .in +4n
@@ -445,7 +446,7 @@ Because of the shared ring buffers between kernel and user space,
 can be a zero-copy system.
 Copying buffers to and from becomes necessary when system calls that
 transfer data between kernel and user space are involved.
-But since the bulk of the communication in 
+But since the bulk of the communication in
 .B io_uring
 is via buffers shared between the kernel and user space,
 this huge performance overhead is completely avoided.
@@ -470,8 +471,8 @@ In
 on the other hand,
 you can batch several requests in one go,
 simply by queueing up multiple SQEs,
-each describing an I/O operation you want and make a single call to 
-.BR io_uring_enter (2). 
+each describing an I/O operation you want and make a single call to
+.BR io_uring_enter (2).
 This is possible due to
 .BR io_uring 's
 shared buffers based design.
@@ -484,7 +485,7 @@ them to the submission queue. This avoids the
 .BR io_uring_enter (2)
 call you need to make to tell the kernel to pick SQEs up.
 For high-performance applications,
-this means even lesser system call overheads.
+this means even fewer system call overheads.
 .SH CONFORMING TO
 .B io_uring
 is Linux-specific.
@@ -531,7 +532,7 @@ provides with its asynchronous processing of requests.
                  memory_order_acquire)
 
 int ring_fd;
-unsigned *sring_tail, *sring_mask, *sring_array, 
+unsigned *sring_tail, *sring_mask, *sring_array,
             *cring_head, *cring_tail, *cring_mask;
 struct io_uring_sqe *sqes;
 struct io_uring_cqe *cqes;
@@ -577,7 +578,7 @@ int app_setup_uring(void) {
     int cring_sz = p.cq_off.cqes + p.cq_entries * sizeof(struct io_uring_cqe);
 
     /* Rather than check for kernel version, the recommended way is to
-     * check the features field of the io_uring_params structure, which is a 
+     * check the features field of the io_uring_params structure, which is a
      * bitmask. If IORING_FEAT_SINGLE_MMAP is set, we can do away with the
      * second mmap() call to map in the completion ring separately.
      */
@@ -720,7 +721,7 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    /* 
+    /*
     * A while loop that reads from stdin and writes to stdout.
     * Breaks on EOF.
     */

--- a/man/io_uring_cq_advance.3
+++ b/man/io_uring_cq_advance.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_cq_advance 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_cq_advance - Mark one or more io_uring completion events as processed
+io_uring_cq_advance - Mark one or more io_uring completion events as consumed
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"
@@ -19,20 +19,22 @@ The io_uring_cq_advance() function marks
 .I nr
 IO completions belonging to the
 .I ring
-param as processed.
+param as consumed.
 
 After the caller has submitted a request with
 .BR io_uring_submit (3),
 the application can retrieve the completion with
 .BR io_uring_wait_cqe (3),
 .BR io_uring_peek_cqe (3),
-or any of the other CQE retrieval helpers, and mark it as processed with
+or any of the other CQE retrieval helpers, and mark it as consumed with
 .BR io_uring_cqe_seen (3).
 
 The function
 .BR io_uring_cqe_seen (3)
 calls the function
 .BR io_uring_cq_advance (3).
+
+.\" COMMENT: Given the above, why would one call this function instead of io_uring_cqe_seen?
 
 Completions must be marked as seen, so their slot can get reused. Failure to do
 so will result in the same completion being returned on the next invocation.

--- a/man/io_uring_cqe_seen.3
+++ b/man/io_uring_cqe_seen.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_cqe_seen 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_cqe_seen - Mark io_uring completion event as processed
+io_uring_cqe_seen - Mark io_uring completion event as consumed
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"
@@ -19,17 +19,17 @@ The io_uring_cqe_seen() function marks the IO completion
 .I cqe
 belonging to the
 .I ring
-param as processed.
+param as consumed.
 
 After the caller has submitted a request with
 .BR io_uring_submit (3),
 the application can retrieve the completion with
 .BR io_uring_wait_cqe (3),
 .BR io_uring_peek_cqe (3),
-or any of the other CQE retrieval helpers, and mark it as processed with
+or any of the other CQE retrieval helpers, and mark it as consumed with
 .BR io_uring_cqe_seen (3).
 
-Completions must be marked as completed, so their slot can get reused.
+Completions must be marked as completed so their slot can get reused.
 .SH RETURN VALUE
 None
 .SH SEE ALSO

--- a/man/io_uring_free_probe.3
+++ b/man/io_uring_free_probe.3
@@ -20,6 +20,8 @@ instance allocated with the
 .BR io_uring_get_probe (3)
 function.
 
+.\" COMMENT: Would it be useful to include or link to a description of what a probe is here and/or why you'd use it?
+
 .SH RETURN VALUE
 None
 .SH SEE ALSO

--- a/man/io_uring_get_probe.3
+++ b/man/io_uring_get_probe.3
@@ -19,6 +19,8 @@ structure to the caller. The caller is responsible for freeing the
 structure with the function
 .BR io_uring_free_probe (3).
 
+.\" COMMENT: Would it be useful to include or link to a description of what a probe is here and/or why you'd use it?
+
 .SH NOTES
 Earlier versions of the Linux kernel do not support probe. If the kernel
 doesn't support probe, this function will return NULL.

--- a/man/io_uring_opcode_supported.3
+++ b/man/io_uring_opcode_supported.3
@@ -10,7 +10,7 @@ io_uring_opcode_supported - is op code supported?
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_opcode_supported(struct io_uring_probe *" probe ","
-.BI "                              int " opode ");"
+.BI "                              int " opcode ");"
 .fi
 .PP
 .SH DESCRIPTION

--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -20,7 +20,7 @@ queue belonging to the
 .I ring
 param, if one is readily available. On successful return,
 .I cqe_ptr
-param is filled with a valud CQE entry.
+param is filled with a valid CQE entry.
 
 This function does not enter the kernel to wait for an event, an event
 is only returned if it's already available in the CQ ring.

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_prep_accept 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_accept  - prepare a accept request
+io_uring_prep_accept  - prepare an accept request
 .fi
 .SH SYNOPSIS
 .nf
@@ -22,7 +22,7 @@ io_uring_prep_accept  - prepare a accept request
 .BI "                                struct sockaddr *" addr ","
 .BI "                                socklen_t " addrlen ","
 .BI "                                int " flags ","
-.BI "                                unsigned int " file_index ");"
+.BI "                                unsigned " file_index ");"
 .PP
 .SH DESCRIPTION
 .PP
@@ -41,7 +41,7 @@ and using modifier flags in
 For a direct descriptor accept request, the offset is specified by the
 .I file_index
 argument. Direct descriptors are io_uring private file descriptors. They
-avoid some of the overhead associated with thread shared file tables, and
+avoid some of the overhead associated with thread shared file tables and
 can be used in any io_uring request that takes a file descriptor. To do so,
 .B IOSQE_FIXED_FILE
 must be set in the SQE

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -29,8 +29,8 @@ in length to update that amount of previously registered files starting at
 offset
 .I offset.
 
-One a previously registered file is updated with a new one, the existing
-entry is updated the removed from the table. This operation is equivalent to
+Once a previously registered file is updated with a new one, the existing
+entry is updated and then removed from the table. This operation is equivalent to
 first unregistering that entry and then inserting a new one, just bundled into
 one combined operation.
 

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -46,6 +46,8 @@ is set in the SQE, then that indicates the size in bytes to sync from the
 offset. Note that these fields are not accepted by this helper, so they have
 to be set manually in the SQE after calling this prep helper.
 
+COMMENTl: Is it useful to say what bad things happen if you set the fields before?
+
 .SH RETURN VALUE
 None
 .SH ERRORS

--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -12,9 +12,9 @@ io_uring_prep_msg_ring   - send a message to another ring
 .PP
 .BI "void io_uring_msg_ring(struct io_uring_sqe *" sqe ","
 .BI "                        int " fd ","
-.BI "                        unsigned int " len ","
+.BI "                        unsigned " len ","
 .BI "                        __u64 " data ","
-.BI "                        unsigned int " flags ");"
+.BI "                        unsigned " flags ");"
 
 .SH DESCRIPTION
 .PP
@@ -38,7 +38,7 @@ Currently there are no valid flag modifiers, this field must contain
 .B 0.
 
 The targeted ring may be any ring that the user has access to, even the ring
-itself. This request can be used for simple message passing to another ring,
+itself (??? why would one do this ???). This request can be used for simple message passing to another ring,
 allowing 32+64 bits of data to be transferred through the
 .I len
 and

--- a/man/io_uring_prep_provide_buffers.3
+++ b/man/io_uring_prep_provide_buffers.3
@@ -54,13 +54,13 @@ field.
 Different buffer group IDs can be used by the application to have different
 sizes or types of buffers available. Once a buffer has been consumed for an
 operation, it is no longer known to io_uring. It must be re-provided if so
-desired, or freed by the application if no longer needed.
+desired or freed by the application if no longer needed.
 
 The buffer IDs are internally tracked from
 .I bid
 and sequentially ascending from that value. If
 .B 16
-buffers are provided start with an initial
+buffers are provided and start with an initial
 .I bid
 of 0, then the buffer IDs will range from
 .B 0..15.

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -33,15 +33,16 @@ at the specified
 and with the buffer matching the registered index of
 .I buf_index.
 
-This work just like
+This works just like
 .B io_uring_prep_read(3)
-except it requires the user of buffers that have been registered with
-.B io_uring_register_buffers(3). The
+except it requires the use of buffers that have been registered with
+.B io_uring_register_buffers(3).
+The
 .I buf
 and
 .I nbytes
 arguments must fall within a region specificed by
-.I buf_index.
+.I buf_index
 in the previously registered buffer. The buffer need not be aligned with
 the start of the registered buffer.
 

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -16,7 +16,7 @@ io_uring_prep_splice  - prepare an splice request
 .BI "                          int64_t " off_in ","
 .BI "                          int " fd_out ","
 .BI "                          int64_t " off_out ","
-.BI "                          unsigned int " nbytes ","
+.BI "                          unsigned " nbytes ","
 .BI "                          int " splice_flags ");"
 .PP
 .SH DESCRIPTION

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -14,7 +14,7 @@ io_uring_prep_tee  - prepare a tee request
 .BI "void io_uring_prep_tee(struct io_uring_sqe *" sqe ","
 .BI "                       int " fd_in ","
 .BI "                       int " fd_out ","
-.BI "                       unsigned int " nbytes ","
+.BI "                       unsigned " nbytes ","
 .BI "                       int " splice_flags ");"
 .PP
 .SH DESCRIPTION
@@ -29,7 +29,7 @@ and as output the file descriptor
 duplicating
 .I nbytes
 bytes worth of data.
-.I flags
+.I splice_flags
 are modifier flags for the operation. See
 .BR tee (2)
 for the generic splice flags.

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -28,7 +28,7 @@ completion entries. The
 .I flags
 argument holds modifier flags for the request.
 
-This request type can either be used as a timeout waking anyone sleeping
+This request type can be used as a timeout waking anyone sleeping
 for events on the CQ ring. The
 .I flags
 argument may contain:
@@ -45,7 +45,7 @@ The boottime clock source should be used.
 The realtime clock source should be used.
 .TP
 .B IORING_TIMEOUT_ETIME_SUCCESS
-Consider an expirted timeout a success in terms of the posted completion.
+Consider an expired timeout a success in terms of the posted completion.
 Normally a timeout that triggers would return in a
 .B -ETIME
 CQE

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -48,7 +48,7 @@ The boottime clock source should be used.
 The realtime clock source should be used.
 .TP
 .B IORING_TIMEOUT_ETIME_SUCCESS
-Consider an expirted timeout a success in terms of the posted completion.
+Consider an expired timeout a success in terms of the posted completion.
 Normally a timeout that triggers would return in a
 .B -ETIME
 CQE

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -36,7 +36,7 @@ incremented by the number of bytes written. See
 .BR write (2)
 for more details. Note that for an async API, reading and updating the
 current file offset may result in unpredictable behavior, unless access
-to the file is serialized. It is not encouraged to use this feature, if it's
+to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
 On files that are not capable of seeking, the offset is ignored.

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -29,19 +29,19 @@ to start writing
 from the buffer
 .I buf
 at the specified
-.I offset,
+.I offset
 and with the buffer matching the registered index of
 .I buf_index.
 
-This work just like
+This works just like
 .B io_uring_prep_write(3)
-except it requires the user of buffers that have been registered with
+except it requires the use of buffers that have been registered with
 .B io_uring_register_buffers(3). The
 .I buf
 and
 .I nbytes
 arguments must fall within a region specificed by
-.I buf_index.
+.I buf_index
 in the previously registered buffer. The buffer need not be aligned with
 the start of the registered buffer.
 

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -38,7 +38,7 @@ incremented by the number of bytes written. See
 .BR write (2)
 for more details. Note that for an async API, reading and updating the
 current file offset may result in unpredictable behavior, unless access
-to the file is serialized. It is not encouraged to use this feature, if it's
+to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
 On files that are not capable of seeking, the offset is ignored.

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -65,7 +65,7 @@ incremented by the number of bytes written. See
 .BR write (2)
 for more details. Note that for an async API, reading and updating the
 current file offset may result in unpredictable behavior, unless access
-to the file is serialized. It is not encouraged to use this feature, if it's
+to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
 On files that are not capable of seeking, the offset is ignored.

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -35,13 +35,13 @@ for the SQ ring. This is adequate for regular file or storage workloads, but
 may be too small networked workloads. The SQ ring entries do not impose a limit
 on the number of in-flight requests that the ring can support, it merely limits
 the number that can be submitted to the kernel in one go (batch). if the CQ
-ring overflows, eg more entries are generated than fits in the ring before the
+ring overflows, e.g. more entries are generated than fits in the ring before the
 application can reap them, then the ring enters a CQ ring overflow state. This
 is indicated by
 .B IORING_SQ_CQ_OVERFLOW
 being set in the SQ ring flags. Unless the kernel runs out of available memory,
 entries are not dropped, but it is a much slower completion path and will slow
-down request processing. For that reason it should be avoided, and the CQ
+down request processing. For that reason it should be avoided and the CQ
 ring sized appropriately for the workload. Setting
 .I cq_entries
 in
@@ -59,7 +59,7 @@ will point to the shared memory containing the io_uring queues. On failure
 is returned.
 
 .I flags
-will be passed through to the io_uring_setup syscall (see 
+will be passed through to the io_uring_setup syscall (see
 .BR io_uring_setup (2)).
 
 If the

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -28,8 +28,8 @@ fixed buffers functions.
 
 Registered buffers is an optimization that is useful in conjunction with
 .B O_DIRECT
-reads and writes, where maps the specified range into the kernel once when
-the buffer is registered, rather than doing a map and unmap for each IO
+reads and writes, where it maps the specified range into the kernel once when
+the buffer is registered rather than doing a map and unmap for each IO
 every time IO is performed to that region. Additionally, it also avoids
 manipulating the page reference counts for each IO.
 

--- a/man/io_uring_register_iowq_max_workers.3
+++ b/man/io_uring_register_iowq_max_workers.3
@@ -11,7 +11,7 @@ io_uring_register_iowq_max_workers  - modify the maximum allowed async workers
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_register_iowq_max_workers(struct io_uring *" ring ","
-.BI "                                       unsigned int *" values ");"
+.BI "                                       unsigned *" values ");"
 .PP
 .SH DESCRIPTION
 .PP

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -46,7 +46,7 @@ last SQE in a submission has this flag set, it will still terminate the current
 chain. This flag has no effect on previous SQE submissions, nor does it impact
 SQEs that are outside of the chain tail. This means that multiple chains can be
 executing in parallel, or chains and individual SQEs. Only members inside the
-chain are serialized. A chain of SQEs will be broken, if any request in that
+chain are serialized. A chain of SQEs will be broken if any request in that
 chain ends in error.
 .TP
 .B IOSQE_IO_DRAIN

--- a/man/io_uring_submit_and_wait_timeout.3
+++ b/man/io_uring_submit_and_wait_timeout.3
@@ -26,7 +26,7 @@ and waits for
 .I wait_nr
 completion events or until the timeout
 .I ts
-expires.The completion events are stored in the
+expires. The completion events are stored in the
 .I cqe_ptr array.
 The
 .I sigmask


### PR DESCRIPTION
- Inconsistencies noticed
	- Use of "consumed" vs "processed" - "consumed" was more common, so I
	  changed the few instances of "processed" to that. It was non-obvious
	  to me if consumption was different from processing, so this removes that
	  ambiguity
	- Use of "unsigned int" vs. "unsigned" (int implied) - latter was far
	  more common, so replaced the few instances of the former with just
	  "unsigned".
- Fixed a few comma splices and typos
- Comments/questions are prefixed with `COMMENT:`
- Also read through some of io_uring.7 as that helped give me context to
  understand the rest.

